### PR TITLE
Disable some modules for multiboot

### DIFF
--- a/recipes-bsp/linux/linux-dreambox-3.14/dm900/defconfig
+++ b/recipes-bsp/linux/linux-dreambox-3.14/dm900/defconfig
@@ -1214,7 +1214,7 @@ CONFIG_MTD_M25P80=y
 # CONFIG_MTD_SLRAM is not set
 # CONFIG_MTD_PHRAM is not set
 # CONFIG_MTD_MTDRAM is not set
-CONFIG_MTD_BLOCK2MTD=m
+# CONFIG_MTD_BLOCK2MTD is not set
 
 #
 # Disk-On-Chip Device Drivers

--- a/recipes-bsp/linux/linux-dreambox-3.14/dm920/defconfig
+++ b/recipes-bsp/linux/linux-dreambox-3.14/dm920/defconfig
@@ -1214,7 +1214,7 @@ CONFIG_MTD_M25P80=y
 # CONFIG_MTD_SLRAM is not set
 # CONFIG_MTD_PHRAM is not set
 # CONFIG_MTD_MTDRAM is not set
-CONFIG_MTD_BLOCK2MTD=m
+# CONFIG_MTD_BLOCK2MTD is not set
 
 #
 # Disk-On-Chip Device Drivers


### PR DESCRIPTION
Image build error

`ERROR: Task (/home/dreamosat/OpenVision/upcoming/meta-dream/recipes-bsp/linux/linux-dreambox_3.14.bb:do_compile_kernelmodules) failed with exit code '1'`